### PR TITLE
Don't showing error view when at least one video is loaded

### DIFF
--- a/picks/Picks Module/PicksView.swift
+++ b/picks/Picks Module/PicksView.swift
@@ -26,7 +26,7 @@ struct PicksView: View {
                     .navigationTitle("Searching ...")
                 }
             }
-            else if presenter.failed() {
+            else if presenter.failed() && presenter.videos.isEmpty {
                 ErrorView(error: presenter.getCurrentError()!, retryHandler: presenter.loadData)
             }
             else {


### PR DESCRIPTION
If the API connection fails but there are loaded videos don't show an error view in the Picks tab bar